### PR TITLE
Add "inf" as a valid float tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+##  [Unreleased]
+
+### Fixed
+
+- handle `inf` float values ([@lucventurini](https://github.com/lucventurini))
+
 ## [0.1.1] - 2020-05-16
 
 ### Added
@@ -15,5 +21,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Don't rely on `poetry` to get version.
 
-
+[Unreleased]: https://github.com/snakemake/snakefmt/compare/0.1.1...HEAD
 [0.1.1]: https://github.com/mbhall88/pafpy/compare/0.1.0...0.1.1

--- a/pafpy/tag.py
+++ b/pafpy/tag.py
@@ -51,7 +51,7 @@ TagTypes = {
     "f": TagType(
         char="f",
         python_type=float,
-        value_regex=re.compile(r"(?P<value>[-+]?\d*\.?\d+([eE][-+]?\d+)?)"),
+        value_regex=re.compile(r"(?P<value>[-+]?(\d*\.?\d+([eE][-+]?\d+)?)|inf)"),
     ),
     "Z": TagType(
         char="Z", python_type=str, value_regex=re.compile(r"(?P<value>[ !-~]*)"),

--- a/tests/test_tag.py
+++ b/tests/test_tag.py
@@ -114,3 +114,14 @@ class TestFromStr:
         expected = Tag(tag, tag_type, value)
 
         assert actual == expected
+
+    def test_tag_with_inf_float_value_parsed(self):
+        tag = "de"
+        tag_type = "f"
+        value = "inf"
+        string = ":".join([tag, tag_type, str(value)])
+
+        actual = Tag.from_str(string)
+        expected = Tag(tag, tag_type, float(value))
+
+        assert actual == expected


### PR DESCRIPTION
Currently PafPy breaks with a valid "inf" value for float values. This PR corrects the regex in this sense.